### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ default = []
 
 [dependencies]
 libc = "*"
-serde = "1.0.8"
-serde_json = "1.0.2"
-serde_derive = "1.0.8"
-reqwest = "0.9.15"
+serde = "1.0.111"
+serde_json = "1.0.55"
+serde_derive = "1.0.111"
+reqwest = "0.9.22"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -14,7 +14,7 @@ pub struct R2PipeAsync {
     rx: Receiver<String>,
     tx2: Sender<String>,
     rx2: Receiver<String>,
-    cbs: Vec<Arc<Fn(String)>>,
+    cbs: Vec<Arc<dyn Fn(String)>>,
 }
 
 impl R2PipeAsync {
@@ -30,7 +30,7 @@ impl R2PipeAsync {
         }
     }
 
-    pub fn cmd(&mut self, str: &'static str, cb: Arc<Fn(String)>) {
+    pub fn cmd(&mut self, str: &'static str, cb: Arc<dyn Fn(String)>) {
         self.cbs.insert(0, cb);
         self.tx.send(str.to_string()).unwrap();
     }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -3,9 +3,6 @@ extern crate serde_json;
 
 use r2pipe::R2Pipe;
 use r2pipe::R2PipeSpawnOptions;
-use std::process;
-
-use serde_json::Value;
 
 fn test_trim() {
     let mut ns = R2Pipe::spawn("/bin/ls".to_owned(), None).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,6 @@
 extern crate libc;
 extern crate serde;
 extern crate serde_json;
-#[macro_use]
 extern crate serde_derive;
 extern crate reqwest;
 

--- a/src/r2.rs
+++ b/src/r2.rs
@@ -13,7 +13,6 @@
 
 use r2pipe::R2Pipe;
 use serde_json;
-use serde_json::Error;
 use serde_json::Value;
 
 pub struct R2 {
@@ -41,16 +40,13 @@ impl R2 {
         // This means that path is `Some` or we have an open session.
         let pipe = open_pipe!(path.as_ref()).unwrap();
         Ok(R2 {
-            pipe: pipe,
+            pipe,
             readin: String::new(),
         })
     }
 
     pub fn in_session() -> bool {
-        match R2Pipe::in_session() {
-            Some(_) => true,
-            None => false,
-        }
+        R2Pipe::in_session().is_some()
     }
 
     pub fn from(r2p: R2Pipe) -> R2 {


### PR DESCRIPTION
**Detailed description**
* Update deps
* Remove all warnings (including `cargo test`) and clippy lints
* Flattened some nested or complicated code blocks to make it more readable 

**Test plan**
* This changes should not affect functionality
* `cargo test` passes (although there seems to be only one)
* Thread examples seem to work fine

**Closing issues**
Can we publish release 0.5.0 to crates.io yet? If not what needs to be done?