### PR TITLE
Move reqwest into an "http" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,11 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
+http = ["reqwest"]
 
 [dependencies]
 libc = "0.2.81"
 serde = "1.0.118"
 serde_json = "1.0.60"
 serde_derive = "1.0.118"
-reqwest = "0.9"
+reqwest = { version = "0.9", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 //! The crate offers various methods to interact with r2pipe, eg. via process (multi-threadable), http or tcp.
 //! Check the examples/ dir for more complete examples.
 
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![doc(html_root_url = "https://radare.github.io/r2pipe.rs/")]
 
 #[macro_use]

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -2,6 +2,7 @@
 //!
 //! Please check crate level documentation for more details and example.
 
+#[cfg(feature = "http")]
 use reqwest;
 
 use libc;
@@ -39,6 +40,8 @@ pub struct R2PipeTcp {
     socket_addr: SocketAddr,
 }
 
+#[cfg(feature = "http")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "http")))]
 pub struct R2PipeHttp {
     host: String,
 }
@@ -64,6 +67,8 @@ pub enum R2Pipe {
     Pipe(R2PipeSpawn),
     Lang(R2PipeLang),
     Tcp(R2PipeTcp),
+    #[cfg(feature = "http")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "http")))]
     Http(R2PipeHttp),
 }
 
@@ -141,6 +146,7 @@ impl R2Pipe {
             R2Pipe::Pipe(ref mut x) => x.cmd(cmd.trim()),
             R2Pipe::Lang(ref mut x) => x.cmd(cmd.trim()),
             R2Pipe::Tcp(ref mut x) => x.cmd(cmd.trim()),
+            #[cfg(feature = "http")]
             R2Pipe::Http(ref mut x) => x.cmd(cmd.trim()),
         }
     }
@@ -150,6 +156,7 @@ impl R2Pipe {
             R2Pipe::Pipe(ref mut x) => x.cmdj(cmd.trim()),
             R2Pipe::Lang(ref mut x) => x.cmdj(cmd.trim()),
             R2Pipe::Tcp(ref mut x) => x.cmdj(cmd.trim()),
+            #[cfg(feature = "http")]
             R2Pipe::Http(ref mut x) => x.cmdj(cmd.trim()),
         }
     }
@@ -159,6 +166,7 @@ impl R2Pipe {
             R2Pipe::Pipe(ref mut x) => x.close(),
             R2Pipe::Lang(ref mut x) => x.close(),
             R2Pipe::Tcp(ref mut x) => x.close(),
+            #[cfg(feature = "http")]
             R2Pipe::Http(ref mut x) => x.close(),
         }
     }
@@ -232,6 +240,8 @@ impl R2Pipe {
         Ok(R2Pipe::Tcp(R2PipeTcp { socket_addr: addr }))
     }
 
+    #[cfg(feature = "http")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "http")))]
     /// Creates a new R2PipeHttp
     pub fn http(host: &str) -> Result<R2Pipe, &'static str> {
         Ok(R2Pipe::Http(R2PipeHttp {
@@ -347,6 +357,8 @@ impl R2PipeLang {
     }
 }
 
+#[cfg(feature = "http")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "http")))]
 impl R2PipeHttp {
     pub fn cmd(&mut self, cmd: &str) -> Result<String, String> {
         let url = format!("http://{}/cmd/{}", self.host, cmd);


### PR DESCRIPTION
**Detailed description**

This is a very heavy dependency, and most may not need it. Instead it should be a compile-time option.

**This is a breaking change**, `http` is NOT enabled by default, so users who want it need to explicitly opt-in after updating.

**Test plan**

Check the default configuration, without `http`:
```
cargo --build
```

Then build with all features, which includes `http`:
```
cargo --build --all-features
```

**Closing issues**

N/A

**Additional notes**

This also annotates the documentation, to tell users that this feature is only available when `http` is enabled:

![image](https://user-images.githubusercontent.com/18178821/118342835-46094f80-b4f3-11eb-8fb6-f0ef0b6a09ee.png)

Use `RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --all-features --open` to view.