### PR TITLE
Take care of the repeated match statements in the impl R2Pipe block

### DIFF
--- a/src/r2.rs
+++ b/src/r2.rs
@@ -70,7 +70,7 @@ impl R2 {
     }
 
     pub fn recv_json(&mut self) -> Result<Value> {
-        let mut res = self.recv().replace("\n", "");
+        let mut res = self.recv().replace('\n', "");
         if res.is_empty() {
             res = "{}".to_owned();
         }

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -66,7 +66,7 @@ pub enum R2Pipe {
     Http(R2PipeHttp),
 }
 
-pub trait Piper {
+pub trait Pipe {
     fn cmd(&mut self, cmd: &str) -> Result<String>;
     fn cmdj(&mut self, cmd: &str) -> Result<Value>;
     fn close(&mut self) {}
@@ -133,7 +133,7 @@ impl R2Pipe {
     pub fn open() -> Result<R2Pipe> {
         unimplemented!()
     }
-    fn get_piper<'a>(&'a mut self) -> &'a mut dyn Piper {
+    fn get_piper<'a>(&'a mut self) -> &'a mut dyn Pipe {
         match *self {
             R2Pipe::Pipe(ref mut x) => x,
             R2Pipe::Lang(ref mut x) => x,
@@ -288,7 +288,7 @@ impl R2PipeThread {
     }
 }
 
-impl Piper for R2PipeSpawn {
+impl Pipe for R2PipeSpawn {
     fn cmd(&mut self, cmd: &str) -> Result<String> {
         let cmd = cmd.to_owned() + "\n";
         self.write.write_all(cmd.as_bytes())?;
@@ -323,7 +323,7 @@ impl R2PipeSpawn {
     }
 }
 
-impl Piper for R2PipeLang {
+impl Pipe for R2PipeLang {
     fn cmd(&mut self, cmd: &str) -> Result<String> {
         self.write.write_all(cmd.as_bytes())?;
         let mut res: Vec<u8> = Vec::new();
@@ -338,7 +338,7 @@ impl Piper for R2PipeLang {
     }
 }
 
-impl Piper for R2PipeHttp {
+impl Pipe for R2PipeHttp {
     fn cmd(&mut self, cmd: &str) -> Result<String> {
         let host = if self.host.starts_with("http://") {
             &self.host[7..]
@@ -367,7 +367,7 @@ impl Piper for R2PipeHttp {
     }
 }
 
-impl Piper for R2PipeTcp {
+impl Pipe for R2PipeTcp {
     fn cmd(&mut self, cmd: &str) -> Result<String> {
         let mut stream = TcpStream::connect(self.socket_addr)?;
         stream.write_all(cmd.as_bytes())?;

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -69,7 +69,7 @@ pub enum R2Pipe {
 pub trait Piper {
     fn cmd(&mut self, cmd: &str) -> Result<String>;
     fn cmdj(&mut self, cmd: &str) -> Result<Value>;
-    fn close(&mut self);
+    fn close(&mut self) {}
 }
 
 fn atoi(k: &str) -> i32 {
@@ -336,10 +336,6 @@ impl Piper for R2PipeLang {
 
         Ok(serde_json::from_str(&res)?)
     }
-    fn close(&mut self) {
-        // self.read.close();
-        // self.write.close();
-    }
 }
 
 impl Piper for R2PipeHttp {
@@ -369,8 +365,6 @@ impl Piper for R2PipeHttp {
         let res = self.cmd(cmd)?;
         Ok(serde_json::from_str(&res)?)
     }
-
-    fn close(&mut self) {}
 }
 
 impl Piper for R2PipeTcp {
@@ -387,6 +381,4 @@ impl Piper for R2PipeTcp {
         let res = self.cmd(cmd)?;
         Ok(serde_json::from_str(&res)?)
     }
-
-    fn close(&mut self) {}
 }

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -133,7 +133,7 @@ impl R2Pipe {
     pub fn open() -> Result<R2Pipe> {
         unimplemented!()
     }
-    fn get_piper<'a>(&'a mut self) -> &'a mut dyn Pipe {
+    fn get_pipe<'a>(&'a mut self) -> &'a mut dyn Pipe {
         match *self {
             R2Pipe::Pipe(ref mut x) => x,
             R2Pipe::Lang(ref mut x) => x,
@@ -142,15 +142,15 @@ impl R2Pipe {
         }
     }
     pub fn cmd(&mut self, cmd: &str) -> Result<String> {
-        self.get_piper().cmd(cmd.trim())
+        self.get_pipe().cmd(cmd.trim())
     }
 
     pub fn cmdj(&mut self, cmd: &str) -> Result<Value> {
-        self.get_piper().cmdj(cmd.trim())
+        self.get_pipe().cmdj(cmd.trim())
     }
 
     pub fn close(&mut self) {
-        self.get_piper().close();
+        self.get_pipe().close();
     }
 
     pub fn in_session() -> Option<(i32, i32)> {

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -133,7 +133,7 @@ impl R2Pipe {
     pub fn open() -> Result<R2Pipe> {
         unimplemented!()
     }
-    fn get_pipe<'a>(&'a mut self) -> &'a mut dyn Pipe {
+    fn get_pipe(&mut self) -> &'_ mut dyn Pipe {
         match *self {
             R2Pipe::Pipe(ref mut x) => x,
             R2Pipe::Lang(ref mut x) => x,


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**
I was browsing the r2pipe.rs code when I noticed a repeated match statement in cmd, cmdj and close.
I thought that since the methods are the same that we could put them in a trait and have a method that does all the matching. I have tested it with main.rs. The result is only a 10 line reduction so I don't know if this is a helpful change considering the added complexity.
<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
