### PR TITLE
Use options in_session

### DIFF
--- a/src/r2.rs
+++ b/src/r2.rs
@@ -70,7 +70,7 @@ impl R2 {
     }
 
     pub fn recv_json(&mut self) -> Result<Value> {
-        let mut res = self.recv().replace("\n", "");
+        let mut res = self.recv().replace('\n', "");
         if res.is_empty() {
             res = "{}".to_owned();
         }

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -66,6 +66,12 @@ pub enum R2Pipe {
     Http(R2PipeHttp),
 }
 
+pub trait Pipe {
+    fn cmd(&mut self, cmd: &str) -> Result<String>;
+    fn cmdj(&mut self, cmd: &str) -> Result<Value>;
+    fn close(&mut self) {}
+}
+
 fn getenv(k: &str) -> Option<i32> {
     match env::var(k) {
         Ok(val) => val.parse::<i32>().ok(),
@@ -123,32 +129,24 @@ impl R2Pipe {
     pub fn open() -> Result<R2Pipe> {
         unimplemented!()
     }
-
-    pub fn cmd(&mut self, cmd: &str) -> Result<String> {
+    fn get_pipe(&mut self) -> &'_ mut dyn Pipe {
         match *self {
-            R2Pipe::Pipe(ref mut x) => x.cmd(cmd.trim()),
-            R2Pipe::Lang(ref mut x) => x.cmd(cmd.trim()),
-            R2Pipe::Tcp(ref mut x) => x.cmd(cmd.trim()),
-            R2Pipe::Http(ref mut x) => x.cmd(cmd.trim()),
+            R2Pipe::Pipe(ref mut x) => x,
+            R2Pipe::Lang(ref mut x) => x,
+            R2Pipe::Tcp(ref mut x) => x,
+            R2Pipe::Http(ref mut x) => x,
         }
+    }
+    pub fn cmd(&mut self, cmd: &str) -> Result<String> {
+        self.get_pipe().cmd(cmd.trim())
     }
 
     pub fn cmdj(&mut self, cmd: &str) -> Result<Value> {
-        match *self {
-            R2Pipe::Pipe(ref mut x) => x.cmdj(cmd.trim()),
-            R2Pipe::Lang(ref mut x) => x.cmdj(cmd.trim()),
-            R2Pipe::Tcp(ref mut x) => x.cmdj(cmd.trim()),
-            R2Pipe::Http(ref mut x) => x.cmdj(cmd.trim()),
-        }
+        self.get_pipe().cmdj(cmd.trim())
     }
 
     pub fn close(&mut self) {
-        match *self {
-            R2Pipe::Pipe(ref mut x) => x.close(),
-            R2Pipe::Lang(ref mut x) => x.close(),
-            R2Pipe::Tcp(ref mut x) => x.close(),
-            R2Pipe::Http(ref mut x) => x.close(),
-        }
+        self.get_pipe().close();
     }
 
     pub fn in_session() -> Option<(i32, i32)> {
@@ -283,8 +281,8 @@ impl R2PipeThread {
     }
 }
 
-impl R2PipeSpawn {
-    pub fn cmd(&mut self, cmd: &str) -> Result<String> {
+impl Pipe for R2PipeSpawn {
+    fn cmd(&mut self, cmd: &str) -> Result<String> {
         let cmd = cmd.to_owned() + "\n";
         self.write.write_all(cmd.as_bytes())?;
 
@@ -293,23 +291,14 @@ impl R2PipeSpawn {
         process_result(res)
     }
 
-    pub fn cmdj(&mut self, cmd: &str) -> Result<Value> {
+    fn cmdj(&mut self, cmd: &str) -> Result<Value> {
         let result = self.cmd(cmd)?;
         if result.is_empty() {
             return Err(Error::EmptyResponse);
         }
         Ok(serde_json::from_str(&result)?)
     }
-
-    /// Attempts to take the pipes underlying child process handle.
-    /// On success the handle is returned.
-    /// If `None` is returned the child handle was already taken previously.
-    /// By using this method you take over the responsibility to `wait()` the child process in order to free all of it's resources.
-    pub fn take_child(&mut self) -> Option<process::Child> {
-        self.child.take()
-    }
-
-    pub fn close(&mut self) {
+    fn close(&mut self) {
         let _ = self.cmd("q!");
         if let Some(child) = &mut self.child {
             let _ = child.wait();
@@ -317,28 +306,33 @@ impl R2PipeSpawn {
     }
 }
 
-impl R2PipeLang {
-    pub fn cmd(&mut self, cmd: &str) -> Result<String> {
+impl R2PipeSpawn {
+    /// Attempts to take the pipes underlying child process handle.
+    /// On success the handle is returned.
+    /// If `None` is returned the child handle was already taken previously.
+    /// By using this method you take over the responsibility to `wait()` the child process in order to free all of it's resources.
+    pub fn take_child(&mut self) -> Option<process::Child> {
+        self.child.take()
+    }
+}
+
+impl Pipe for R2PipeLang {
+    fn cmd(&mut self, cmd: &str) -> Result<String> {
         self.write.write_all(cmd.as_bytes())?;
         let mut res: Vec<u8> = Vec::new();
         self.read.read_until(0u8, &mut res)?;
         process_result(res)
     }
 
-    pub fn cmdj(&mut self, cmd: &str) -> Result<Value> {
+    fn cmdj(&mut self, cmd: &str) -> Result<Value> {
         let res = self.cmd(cmd)?;
 
         Ok(serde_json::from_str(&res)?)
     }
-
-    pub fn close(&mut self) {
-        // self.read.close();
-        // self.write.close();
-    }
 }
 
-impl R2PipeHttp {
-    pub fn cmd(&mut self, cmd: &str) -> Result<String> {
+impl Pipe for R2PipeHttp {
+    fn cmd(&mut self, cmd: &str) -> Result<String> {
         let host = if self.host.starts_with("http://") {
             &self.host[7..]
         } else {
@@ -360,16 +354,14 @@ impl R2PipeHttp {
         Ok(str::from_utf8(&resp[index..]).map(|s| s.to_string())?)
     }
 
-    pub fn cmdj(&mut self, cmd: &str) -> Result<Value> {
+    fn cmdj(&mut self, cmd: &str) -> Result<Value> {
         let res = self.cmd(cmd)?;
         Ok(serde_json::from_str(&res)?)
     }
-
-    pub fn close(&mut self) {}
 }
 
-impl R2PipeTcp {
-    pub fn cmd(&mut self, cmd: &str) -> Result<String> {
+impl Pipe for R2PipeTcp {
+    fn cmd(&mut self, cmd: &str) -> Result<String> {
         let mut stream = TcpStream::connect(self.socket_addr)?;
         stream.write_all(cmd.as_bytes())?;
         let mut res: Vec<u8> = Vec::new();
@@ -378,10 +370,8 @@ impl R2PipeTcp {
         process_result(res)
     }
 
-    pub fn cmdj(&mut self, cmd: &str) -> Result<Value> {
+    fn cmdj(&mut self, cmd: &str) -> Result<Value> {
         let res = self.cmd(cmd)?;
         Ok(serde_json::from_str(&res)?)
     }
-
-    pub fn close(&mut self) {}
 }


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
This PR remove the `atoi` function because it is unnecessary  and makes the return type of `getenv` an `Option<i32>` because this is how it should be. The rest of the changes are due to nvim complaining about mixed indentation