### PR TITLE
Add support for r2 native

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,3 @@ jobs:
               with:
                   command: clippy
                   args: -- -D warnings
-
-
-
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,3 +36,7 @@ jobs:
               with:
                   command: clippy
                   args: -- -D warnings
+
+
+
+

--- a/src/dlfcn.rs
+++ b/src/dlfcn.rs
@@ -5,7 +5,7 @@ pub struct LibHandle(std::sync::Mutex<*mut c_void>);
 
 pub fn to_cstr(s: &str) -> Result<*const c_char> {
     Ok(std::ffi::CString::new(s)
-        .or_else(|_| Err(Error::LibError))?
+        .map_err(|_| Error::LibError)?
         .into_raw())
 }
 

--- a/src/dlfcn.rs
+++ b/src/dlfcn.rs
@@ -3,13 +3,13 @@ use libc::*;
 //Conatins the lib
 pub struct LibHandle(std::sync::Mutex<*mut c_void>);
 
-fn to_cstr(s: &str) -> Result<*const c_char> {
+pub fn to_cstr(s: &str) -> Result<*const c_char> {
     Ok(std::ffi::CString::new(s)
         .or_else(|_| Err(Error::LibError))?
         .into_raw())
 }
 
-fn free_cstr(ptr: *const c_char) {
+pub fn free_cstr(ptr: *const c_char) {
     let _ = unsafe { std::ffi::CString::from_raw(ptr as *mut _) };
 }
 

--- a/src/dlfcn.rs
+++ b/src/dlfcn.rs
@@ -1,0 +1,3 @@
+use libc::*;
+//Conatins the lib
+pub struct LibHandle(std::sync::Mutex<*mut c_void>);

--- a/src/dlfcn.rs
+++ b/src/dlfcn.rs
@@ -62,6 +62,12 @@ impl Drop for LibHandle {
 mod tests {
     #[test]
     fn load_lib_test() {
-        let _lib = super::LibHandle::new("libc", Some(".6")).unwrap();
+        let mut _lib = super::LibHandle::new("libc", Some(".6")).unwrap();
+    }
+    #[test]
+    fn load_sym_test() {
+        let mut lib = super::LibHandle::new("libm", Some(".6")).unwrap();
+        let sqrt: fn(libc::c_double) -> libc::c_double = lib.load_sym("sqrt").unwrap();
+        assert_eq!(sqrt(4.0), 2.0);
     }
 }

--- a/src/dlfcn.rs
+++ b/src/dlfcn.rs
@@ -57,17 +57,3 @@ impl Drop for LibHandle {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn load_lib_test() {
-        let mut _lib = super::LibHandle::new("libc", Some(".6")).unwrap();
-    }
-    #[test]
-    fn load_sym_test() {
-        let mut lib = super::LibHandle::new("libm", Some(".6")).unwrap();
-        let sqrt: fn(libc::c_double) -> libc::c_double = lib.load_sym("sqrt").unwrap();
-        assert_eq!(sqrt(4.0), 2.0);
-    }
-}

--- a/src/dlfcn.rs
+++ b/src/dlfcn.rs
@@ -1,3 +1,54 @@
+use crate::{Error, Result};
 use libc::*;
 //Conatins the lib
 pub struct LibHandle(std::sync::Mutex<*mut c_void>);
+
+fn to_cstr(s: &str) -> Result<*const c_char> {
+    Ok(std::ffi::CString::new(s)
+        .or_else(|_| Err(Error::LibError))?
+        .into_raw())
+}
+
+fn free_cstr(ptr: *const c_char) {
+    let _ = unsafe { std::ffi::CString::from_raw(ptr as *mut _) };
+}
+
+impl LibHandle {
+    pub fn new(name: &str) -> Result<LibHandle> {
+        let name = to_cstr(&format!(
+            "{}{}",
+            name,
+            if cfg!(windows) {
+                ".dll"
+            } else if cfg!(macos) {
+                ".dylib"
+            } else {
+                ".so"
+            }
+        ))?;
+        let ret = unsafe { dlopen(name, RTLD_LAZY) };
+        free_cstr(name);
+        if ret.is_null() {
+            Err(Error::LibError)
+        } else {
+            Ok(LibHandle(std::sync::Mutex::new(ret)))
+        }
+    }
+    pub fn load_sym<T>(&mut self, name: &str) -> T {
+        todo!();
+    }
+}
+
+impl Drop for LibHandle {
+    fn drop(&mut self) {
+        todo!();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn load_test() {
+        let _lib = super::LibHandle::new("libr_core").unwrap();
+    }
+}

--- a/src/dlfcn.rs
+++ b/src/dlfcn.rs
@@ -35,15 +35,15 @@ impl LibHandle {
             Ok(LibHandle(std::sync::Mutex::new(ret)))
         }
     }
-    pub fn load_sym<T>(&mut self, name: &str) -> Result<T> {
+    pub unsafe fn load_sym<T>(&mut self, name: &str) -> Result<T> {
         let handle = *self.0.lock().unwrap();
         let name = to_cstr(name)?;
-        let sym = unsafe { dlsym(handle, name) };
+        let sym = dlsym(handle, name);
         free_cstr(name);
         if sym.is_null() {
             Err(Error::LibError)
         } else {
-            Ok(unsafe { std::mem::transmute_copy(&sym) })
+            Ok(std::mem::transmute_copy(&sym))
         }
     }
 }

--- a/src/dlfcn.rs
+++ b/src/dlfcn.rs
@@ -41,7 +41,8 @@ impl LibHandle {
 
 impl Drop for LibHandle {
     fn drop(&mut self) {
-        todo!();
+        let handle = *self.0.lock().unwrap();
+        unsafe { libc::dlclose(handle) };
     }
 }
 

--- a/src/dlfcn.rs
+++ b/src/dlfcn.rs
@@ -1,11 +1,12 @@
 use crate::{Error, Result};
 use libc::*;
-//Conatins the lib
+
+// Contains a handle to the library.
 pub struct LibHandle(std::sync::Mutex<*mut c_void>);
 
 pub fn to_cstr(s: &str) -> Result<*const c_char> {
     Ok(std::ffi::CString::new(s)
-        .map_err(|_| Error::LibError)?
+        .map_err(|_| Error::SharedLibraryLoadError)?
         .into_raw())
 }
 
@@ -30,18 +31,19 @@ impl LibHandle {
         let ret = unsafe { dlopen(name, RTLD_LAZY) };
         free_cstr(name);
         if ret.is_null() {
-            Err(Error::LibError)
+            Err(Error::SharedLibraryLoadError)
         } else {
             Ok(LibHandle(std::sync::Mutex::new(ret)))
         }
     }
+
     pub unsafe fn load_sym<T>(&mut self, name: &str) -> Result<T> {
         let handle = *self.0.lock().unwrap();
         let name = to_cstr(name)?;
         let sym = dlsym(handle, name);
         free_cstr(name);
         if sym.is_null() {
-            Err(Error::LibError)
+            Err(Error::SharedLibraryLoadError)
         } else {
             Ok(std::mem::transmute_copy(&sym))
         }
@@ -51,9 +53,8 @@ impl LibHandle {
 impl Drop for LibHandle {
     fn drop(&mut self) {
         let handle = *self.0.lock().unwrap();
-        let ret = unsafe { libc::dlclose(handle) };
-        if ret != 0 {
-            panic!("Failed to close the lib");
-        }
+        // In some cases, dlclose is not required to do anything. We allow it
+        // to silently fail.
+        let _ = unsafe { libc::dlclose(handle) };
     }
 }

--- a/src/dlfcn.rs
+++ b/src/dlfcn.rs
@@ -42,7 +42,10 @@ impl LibHandle {
 impl Drop for LibHandle {
     fn drop(&mut self) {
         let handle = *self.0.lock().unwrap();
-        unsafe { libc::dlclose(handle) };
+        let ret = unsafe { libc::dlclose(handle) };
+        if ret != 0 {
+            panic!("Failed to close the lib");
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,8 @@ pub enum Error {
     /// Error sending data through channel.
     #[error("Send channel data error")]
     ChannelSendError(#[from] SendError<String>),
-    #[error("lib error")]
-    LibError,
+
+    /// Error loading radare2 shared library.
+    #[error("Shared library load error")]
+    SharedLibraryLoadError,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,4 +40,6 @@ pub enum Error {
     /// Error sending data through channel.
     #[error("Send channel data error")]
     ChannelSendError(#[from] SendError<String>),
+    #[error("lib error")]
+    LibError,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 
 #[macro_use]
 pub mod r2pipe;
+mod dlfcn;
 pub mod r2;
 
 mod error;

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -104,7 +104,7 @@ macro_rules! open_pipe {
     };
         ($x: expr) => {
             match $x {
-                Some(path) => R2Pipe::load_native(path).or_else(|_| R2Pipe::spawn(path, None)),
+                Some(path) => R2Pipe::load_native(&path.clone()).or_else(|_| R2Pipe::spawn(path, None)),
                 None => R2Pipe::open(),
             }
         };

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -401,10 +401,10 @@ impl Pipe for R2PipeNative {
         let r_core = *self.r_core.lock().unwrap();
         let cmd = dlfcn::to_cstr(cmd)?;
         let res = (self.r_core_cmd_str_handle)(r_core, cmd);
-        if !res.is_null() {
+        if res.is_null() {
             Err(Error::EmptyResponse)
         } else {
-            Ok(unsafe { std::ffi::CStr::from_ptr(cmd).to_str()?.to_string() })
+            Ok(unsafe { std::ffi::CStr::from_ptr(res).to_str()?.to_string() })
         }
     }
     fn cmdj(&mut self, cmd: &str) -> Result<Value> {
@@ -437,7 +437,6 @@ mod test {
     #[test]
     fn native_test() {
         let mut r2p = R2PipeNative::open("/bin/ls").unwrap();
-        let a = r2p.cmd("aaa").unwrap();
-        println!("{}", a);
+        assert_eq!("a\n", r2p.cmd("echo a").unwrap());
     }
 }

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -416,7 +416,9 @@ impl Pipe for R2PipeNative {
 impl Drop for R2PipeNative {
     fn drop(&mut self) {
         let r_core = *self.r_core.lock().unwrap();
-        if let Ok(r_core_free) = self.lib.load_sym::<fn(*mut libc::c_void)>("r_core_free") {
+        if let Ok(r_core_free) =
+            unsafe { self.lib.load_sym::<fn(*mut libc::c_void)>("r_core_free") }
+        {
             r_core_free(r_core);
         }
     }

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -421,6 +421,7 @@ impl Drop for R2PipeNative {
         }
     }
 }
+<<<<<<< HEAD
 
 #[cfg(test)]
 mod test {
@@ -440,3 +441,5 @@ mod test {
         assert_eq!("a\n", r2p.cmd("echo a").unwrap());
     }
 }
+=======
+>>>>>>> ae8647a (Remove R2Native tests and revert ci changes)

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -398,10 +398,18 @@ impl R2PipeNative {
 
 impl Pipe for R2PipeNative {
     fn cmd(&mut self, cmd: &str) -> Result<String> {
-        todo!()
+        let r_core = *self.r_core.lock().unwrap();
+        let cmd = dlfcn::to_cstr(cmd)?;
+        let res = (self.r_core_cmd_str_handle)(r_core, cmd);
+        if !res.is_null() {
+            Err(Error::EmptyResponse)
+        } else {
+            Ok(unsafe { std::ffi::CStr::from_ptr(cmd).to_str()?.to_string() })
+        }
     }
     fn cmdj(&mut self, cmd: &str) -> Result<Value> {
-        todo!()
+        let res = self.cmd(cmd)?;
+        Ok(serde_json::from_str(&res)?)
     }
 }
 

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -382,7 +382,7 @@ impl R2PipeNative {
         let r_core_new: fn() -> *mut libc::c_void = lib.load_sym("r_core_new")?;
         let r_core_cmd_str_handle = lib.load_sym("r_core_cmd_str")?;
         let r_core = r_core_new();
-        if !r_core.is_null() {
+        if r_core.is_null() {
             Err(Error::LibError)
         } else {
             let mut ret = R2PipeNative {

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -117,6 +117,9 @@ macro_rules! open_pipe {
 }
 
 impl R2Pipe {
+    pub fn load_native(path: &str) -> Result<R2Pipe> {
+        Ok(R2Pipe(Box::new(R2PipeNative::open(path)?)))
+    }
     #[cfg(not(windows))]
     pub fn open() -> Result<R2Pipe> {
         use std::os::unix::io::FromRawFd;

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -379,8 +379,8 @@ pub struct R2PipeNative {
 impl R2PipeNative {
     pub fn open(file: &str) -> Result<R2PipeNative> {
         let mut lib = dlfcn::LibHandle::new("libr_core", None)?;
-        let r_core_new: fn() -> *mut libc::c_void = lib.load_sym("r_core_new")?;
-        let r_core_cmd_str_handle = lib.load_sym("r_core_cmd_str")?;
+        let r_core_new: fn() -> *mut libc::c_void = unsafe { lib.load_sym("r_core_new")? };
+        let r_core_cmd_str_handle = unsafe { lib.load_sym("r_core_cmd_str")? };
         let r_core = r_core_new();
         if r_core.is_null() {
             Err(Error::LibError)

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -104,7 +104,7 @@ macro_rules! open_pipe {
     };
         ($x: expr) => {
             match $x {
-                Some(path) => R2Pipe::spawn(path, None),
+                Some(path) => R2Pipe::load_native(path).or_else(|_| R2Pipe::spawn(path, None)),
                 None => R2Pipe::open(),
             }
         };
@@ -117,8 +117,8 @@ macro_rules! open_pipe {
 }
 
 impl R2Pipe {
-    pub fn load_native(path: &str) -> Result<R2Pipe> {
-        Ok(R2Pipe(Box::new(R2PipeNative::open(path)?)))
+    pub fn load_native<T: AsRef<str>>(path: T) -> Result<R2Pipe> {
+        Ok(R2Pipe(Box::new(R2PipeNative::open(path.as_ref())?)))
     }
     #[cfg(not(windows))]
     pub fn open() -> Result<R2Pipe> {

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -2,6 +2,7 @@
 //!
 //! Please check crate level documentation for more details and example.
 
+use crate::dlfcn;
 use crate::{Error, Result};
 
 use std::env;
@@ -367,6 +368,12 @@ impl Pipe for R2PipeTcp {
         res.push(0);
         process_result(res)
     }
+}
+
+pub struct R2PipeNative {
+    lib: dlfcn::LibHandle,
+    r_core: std::sync::Mutex<*mut libc::c_void>,
+    r_core_cmd_str_handle: fn(*mut libc::c_void, *const libc::c_char),
 }
 
 #[cfg(test)]

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -425,10 +425,19 @@ impl Drop for R2PipeNative {
 #[cfg(test)]
 mod test {
     use crate::R2Pipe;
+    use super::Pipe;
+    use super::R2PipeNative;
 
     #[test]
     fn spawn_test() {
         let mut pipe = R2Pipe::spawn("/bin/ls", None).unwrap();
         assert_eq!(pipe.cmd("echo test").unwrap(), "test\n");
+    }
+
+    #[test]
+    fn native_test() {
+        let mut r2p = R2PipeNative::open("/bin/ls").unwrap();
+        let a = r2p.cmd("aaa").unwrap();
+        println!("{}", a);
     }
 }

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -407,10 +407,6 @@ impl Pipe for R2PipeNative {
             Ok(unsafe { std::ffi::CStr::from_ptr(res).to_str()?.to_string() })
         }
     }
-    fn cmdj(&mut self, cmd: &str) -> Result<Value> {
-        let res = self.cmd(cmd)?;
-        Ok(serde_json::from_str(&res)?)
-    }
 }
 
 impl Drop for R2PipeNative {

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -413,6 +413,15 @@ impl Pipe for R2PipeNative {
     }
 }
 
+impl Drop for R2PipeNative {
+    fn drop(&mut self) {
+        let r_core = *self.r_core.lock().unwrap();
+        if let Ok(r_core_free) = self.lib.load_sym::<fn(*mut libc::c_void)>("r_core_free") {
+            r_core_free(r_core);
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::R2Pipe;

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -386,7 +386,7 @@ impl R2PipeNative {
         let r_core_cmd_str_handle = unsafe { lib.load_sym("r_core_cmd_str")? };
         let r_core = r_core_new();
         if r_core.is_null() {
-            Err(Error::LibError)
+            Err(Error::SharedLibraryLoadError)
         } else {
             let mut ret = R2PipeNative {
                 lib,
@@ -422,13 +422,12 @@ impl Drop for R2PipeNative {
         }
     }
 }
-<<<<<<< HEAD
 
 #[cfg(test)]
 mod test {
-    use crate::R2Pipe;
     use super::Pipe;
     use super::R2PipeNative;
+    use crate::R2Pipe;
 
     #[test]
     fn spawn_test() {
@@ -442,5 +441,3 @@ mod test {
         assert_eq!("a\n", r2p.cmd("echo a").unwrap());
     }
 }
-=======
->>>>>>> ae8647a (Remove R2Native tests and revert ci changes)


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

This hopes to add support for using r2pipe.rs as seen in r2pipe-go. It uses the dlopen and dlsym libc functions and libr_core.