### PR TITLE
Bump the version to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r2pipe"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
   "pancake <pancake@nopcode.org>",
   "sushant94 <sushant.dinesh94@gmail.com>"


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**
This PR bumps the version to 0.7.0. This is necessary because of the  windows fix: https://github.com/radareorg/r2pipe.rs/pull/51.
![image](https://i.imgur.com/DrlUPAh.png)