### PR TITLE
provide information on premature exits of the radare2 process

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::process::ExitStatus;
 use std::sync::mpsc::{RecvError, SendError, TryRecvError};
 use std::{io, str};
 use thiserror::Error;
@@ -44,4 +45,8 @@ pub enum Error {
     /// Error loading radare2 shared library.
     #[error("Shared library load error")]
     SharedLibraryLoadError,
+
+    /// radare2 exited unexpectedly
+    #[error("Program exited unexpectedly")]
+    ProgramExited { exit_status: ExitStatus },
 }

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -188,12 +188,12 @@ impl R2Pipe {
     }
 
     /// Creates a new R2PipeSpawn.
-    pub fn spawn<T: AsRef<str>>(name: T, mut opts: Option<R2PipeSpawnOptions>) -> Result<R2Pipe> {
+    pub fn spawn<T: AsRef<str>>(name: T, opts: Option<R2PipeSpawnOptions>) -> Result<R2Pipe> {
         if name.as_ref() == "" && R2Pipe::in_session().is_some() {
             return R2Pipe::open();
         }
 
-        let R2PipeSpawnOptions { exepath, args } = opts.take().unwrap_or_default();
+        let R2PipeSpawnOptions { exepath, args } = opts.unwrap_or_default();
 
         let path = Path::new(name.as_ref());
         let mut child = Command::new(exepath)

--- a/src/r2pipe.rs
+++ b/src/r2pipe.rs
@@ -31,7 +31,7 @@ pub struct R2PipeLang {
 pub struct R2PipeSpawn {
     read: BufReader<process::ChildStdout>,
     write: process::ChildStdin,
-    child: Option<process::Child>,
+    child: process::Child,
 }
 
 /// Stores the socket address of the r2 process.
@@ -215,7 +215,7 @@ impl R2Pipe {
         let res = R2PipeSpawn {
             read: BufReader::new(sout),
             write: sin,
-            child: Some(child),
+            child,
         };
 
         Ok(R2Pipe(Box::new(res)))
@@ -311,19 +311,7 @@ impl Pipe for R2PipeSpawn {
 
     fn close(&mut self) {
         let _ = self.cmd("q!");
-        if let Some(child) = &mut self.child {
-            let _ = child.wait();
-        }
-    }
-}
-
-impl R2PipeSpawn {
-    /// Attempts to take the pipes underlying child process handle.
-    /// On success the handle is returned.
-    /// If `None` is returned the child handle was already taken previously.
-    /// By using this method you take over the responsibility to `wait()` the child process in order to free all of it's resources.
-    pub fn take_child(&mut self) -> Option<process::Child> {
-        self.child.take()
+        let _ = self.child.wait();
     }
 }
 


### PR DESCRIPTION
While trying to use this crate inside a threadpool to do automated analysis of many binaries at once, I loaded down my system and had some spurious errors reported from 1) segmentation faults in the radare2 process itself due to uninitialized data and 2) a race condition where the managing process was trying to read the initial NULL byte from the subprocess and the subprocess hadn't initialized enough to a point to bind to the pipe. In both cases, r2pipe simply returned an error of "unexpected EOF" and, at least in the 2nd case, it was truly a case where r2pipe could have retried and succeeded instead of aborting the spawn completely. In the 1st case, I wound up manually hacking the r2pipe crate to figure out that the radare2 process was segfaulting, so I felt it was worthwhile reporting the exit status back in those cases so that end users can at least check on that case and decide what to do.

Additionally, I did a couple of cleanups in the first two commits to make it easier to make the latter two commits. 